### PR TITLE
Add set inccommnand=nosplit

### DIFF
--- a/.config/nvim/init.vim
+++ b/.config/nvim/init.vim
@@ -101,6 +101,8 @@ set smartcase "検索文字列に大文字が含まれている場合は区別�
 set wrapscan "検索時に最後まで行ったら最初に戻る
 set incsearch "インクリメントサーチ
 set hlsearch
+" 置換のハイライトをONにするために有効にした ref: neovim/neovim #12308
+set inccommand=nosplit
 filetype plugin on
 
 " rg があれば vimgrep の代わりに使う


### PR DESCRIPTION
置換のハイライトをONにするために有効にした ref: neovim/neovim #12308
